### PR TITLE
created a MemcachedResponse decoder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ]
         ),

--- a/Sources/SwiftMemcache/Extensions/UInt16+ResponseStatus.swift
+++ b/Sources/SwiftMemcache/Extensions/UInt16+ResponseStatus.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+typealias ResponseStatus = UInt16
+
+extension ResponseStatus {
+    // generates a 16-bit code from two ASCII characters
+    static func generateCode(from characters: (UInt8, UInt8)) -> ResponseStatus {
+        return ResponseStatus(characters.0) << 8 | ResponseStatus(characters.1)
+    }
+
+    static let stored = generateCode(from: (.init(ascii: "H"), .init(ascii: "D")))
+    static let notStored = generateCode(from: (.init(ascii: "N"), .init(ascii: "S")))
+    static let exists = generateCode(from: (.init(ascii: "E"), .init(ascii: "X")))
+    static let notFound = generateCode(from: (.init(ascii: "N"), .init(ascii: "F")))
+
+    init?(asciiValues: (UInt8, UInt8)) {
+        let code = ResponseStatus(asciiValues.0) << 8 | ResponseStatus(asciiValues.1)
+
+        switch code {
+        case ResponseStatus.stored, ResponseStatus.notStored, ResponseStatus.exists, ResponseStatus.notFound:
+            self = code
+        default:
+            preconditionFailure("Unrecognized response code.")
+        }
+    }
+}

--- a/Sources/SwiftMemcache/MemcachedResponse.swift
+++ b/Sources/SwiftMemcache/MemcachedResponse.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+enum MemcachedResponse {
+    struct SetResponse {
+        let status: ResponseStatus
+        let flags: ByteBuffer?
+    }
+
+    case set(SetResponse)
+}

--- a/Sources/SwiftMemcache/MemcachedResponseDecoder.swift
+++ b/Sources/SwiftMemcache/MemcachedResponseDecoder.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOPosix
+
+struct MemcachedResponseDecoder: ByteToMessageDecoder {
+    typealias InboundOut = MemcachedResponse
+
+    var cumulationBuffer: ByteBuffer?
+
+    func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+        // Ensure the buffer has at least 3 bytes (minimum for a response code and newline)
+        guard buffer.readableBytes >= 3 else {
+            return .needMoreData
+        }
+
+        guard let asciiValue1 = buffer.readInteger(as: UInt8.self),
+              let asciiValue2 = buffer.readInteger(as: UInt8.self),
+              let responseCode = ResponseStatus(asciiValues: (asciiValue1, asciiValue2)) else {
+            preconditionFailure("Response code could not be read.")
+        }
+
+        var flags: ByteBuffer?
+
+        // Check if there's a whitespace character, this indicates flags are present
+        if buffer.readableBytes > 2, buffer.getInteger(at: buffer.readerIndex, as: UInt8.self) == UInt8.whitespace {
+            buffer.moveReaderIndex(forwardBy: 1)
+
+            // -2 for \r\n
+            flags = buffer.readSlice(length: buffer.readableBytes - 2)
+        }
+
+        guard buffer.readInteger(as: UInt8.self) == UInt8.carriageReturn,
+              buffer.readInteger(as: UInt8.self) == UInt8.newline else {
+            preconditionFailure("Line ending '\r\n' not found after the flags.")
+        }
+
+        let setResponse = MemcachedResponse.SetResponse(status: responseCode, flags: flags)
+        context.fireChannelRead(self.wrapInboundOut(.set(setResponse)))
+        return .continue
+    }
+
+    func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+        return try self.decode(context: context, buffer: &buffer)
+    }
+}

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedResponseDecoderTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedResponseDecoderTests.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+@testable import SwiftMemcache
+import XCTest
+
+final class MemcachedResponseDecoderTests: XCTestCase {
+    var decoder: MemcachedResponseDecoder!
+    var channel: EmbeddedChannel!
+
+    override func setUp() {
+        super.setUp()
+        self.decoder = MemcachedResponseDecoder()
+        self.channel = EmbeddedChannel(handler: ByteToMessageHandler(self.decoder))
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try self.channel.finish())
+    }
+
+    private func testDecodeSetResponse(responseCode: [UInt8], expectedResponseCode: ResponseStatus, expectedFlags: ByteBuffer? = nil) throws {
+        // Prepare a response buffer with a response code
+        var buffer = ByteBufferAllocator().buffer(capacity: 8)
+        buffer.writeBytes(responseCode)
+
+        buffer.writeBytes([UInt8.carriageReturn, UInt8.newline])
+
+        // Pass our response through the decoder
+        XCTAssertNoThrow(try self.channel.writeInbound(buffer))
+
+        // Read the decoded response
+        if let decoded = try self.channel.readInbound(as: MemcachedResponse.self) {
+            switch decoded {
+            case .set(let setResponse):
+                XCTAssertEqual(setResponse.status, expectedResponseCode)
+            }
+        } else {
+            XCTFail("Failed to decode the inbound response.")
+        }
+    }
+
+    func testDecodeSetStoredResponse() throws {
+        let storedResponseCode = [UInt8(ascii: "H"), UInt8(ascii: "D")]
+        try testDecodeSetResponse(responseCode: storedResponseCode, expectedResponseCode: .stored)
+    }
+
+    func testDecodeSetNotStoredResponse() throws {
+        let notStoredResponseCode = [UInt8(ascii: "N"), UInt8(ascii: "S")]
+        try testDecodeSetResponse(responseCode: notStoredResponseCode, expectedResponseCode: .notStored)
+    }
+
+    func testDecodeSetExistResponse() throws {
+        let existResponseCode = [UInt8(ascii: "E"), UInt8(ascii: "X")]
+        try testDecodeSetResponse(responseCode: existResponseCode, expectedResponseCode: .exists)
+    }
+
+    func testDecodeSetNotFoundResponse() throws {
+        let notFoundResponseCode = [UInt8(ascii: "N"), UInt8(ascii: "F")]
+        try testDecodeSetResponse(responseCode: notFoundResponseCode, expectedResponseCode: .notFound)
+    }
+}


### PR DESCRIPTION
Created a decoder handler that can transform a ByteBuffer received from the Memcached server into a `MemcachedResponse`. This PR will close #5.

**Motivation**:

This marks the beginning for future implementations of decoding a `MemcachedResponse`.

**Modifications**:

Implemented definition of a basic `MemcachedResponse`.
Implemented a basic decoder to deserialize a `MemcachedResponse`.
Added Unit and updated our Integration test.

**Result**:

We can now successfully decode a MemcachedResponse received from the Memcached server.