### PR TITLE
Implement MemcachedFlag for Get Commands

### DIFF
--- a/Sources/SwiftMemcache/MemcachedFlag.swift
+++ b/Sources/SwiftMemcache/MemcachedFlag.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+enum MemcachedFlag {
+    /// v: return item value in <data block>
+    case v
+
+    var bytes: UInt8 {
+        switch self {
+        case .v:
+            return 0x76
+        }
+    }
+}

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagTests.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-memcache-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-memcache-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-memcache-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SwiftMemcache
+import XCTest
+
+final class MemcachedFlagTests: XCTestCase {
+    func testVFlagBytes() {
+        let flag = MemcachedFlag.v
+        XCTAssertEqual(flag.bytes, 0x76)
+    }
+}


### PR DESCRIPTION
Defined and implemented our initial `MemcachedFlag` enum focusing specifically on the `v` flag which is essential for retrieving values associate with a given key. This PR will close #12.

**Motivation**:

This marks the beginning for being able to handle retrieving values associated with a given key. 

**Modifications**:

Implemented definition of a basic `MemcachedFlag`.
Added `MemcachedFlag` Unit test.

**Result**:

We now have the basic foundation needed in order to associate flags with our Memcached commands.