### PR TITLE
Implement Delete Operation Support

### DIFF
--- a/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
+++ b/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
@@ -19,6 +19,7 @@ extension UInt8 {
     static var m: UInt8 = .init(ascii: "m")
     static var s: UInt8 = .init(ascii: "s")
     static var g: UInt8 = .init(ascii: "g")
+    static var d: UInt8 = .init(ascii: "d")
     static var v: UInt8 = .init(ascii: "v")
     static var T: UInt8 = .init(ascii: "T")
     static var zero: UInt8 = .init(ascii: "0")

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -253,9 +253,9 @@ public actor MemcachedConnection {
     /// Delete the value for a key from the Memcache server.
     ///
     /// - Parameter key: The key of the item to be deleted.
-    /// - Returns: A boolean indicating whether the deletion was successful.
     /// - Throws: A `MemcachedConnectionError.connectionShutdown` error if the connection to the Memcache server is shut down.
-    public func delete(_ key: String) async throws -> Bool {
+    /// - Throws: A `MemcachedConnectionError.unexpectedNilResponse` error if the key was not found or if an unexpected response code was returned.
+    public func delete(_ key: String) async throws {
         switch self.state {
         case .initial(_, _, _, _),
              .running:
@@ -267,11 +267,11 @@ public actor MemcachedConnection {
 
             switch response.returnCode {
             case .HD:
-                return true
+                return
             case .NF:
-                return false
+                throw MemcachedConnectionError.unexpectedNilResponse
             default:
-                return false
+                throw MemcachedConnectionError.unexpectedNilResponse
             }
 
         case .finished:

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -247,4 +247,35 @@ public actor MemcachedConnection {
             throw MemcachedConnectionError.connectionShutdown
         }
     }
+
+    // MARK: - Deleting a Value
+
+    /// Delete the value for a key from the Memcache server.
+    ///
+    /// - Parameter key: The key of the item to be deleted.
+    /// - Returns: A boolean indicating whether the deletion was successful.
+    /// - Throws: A `MemcachedConnectionError.connectionShutdown` error if the connection to the Memcache server is shut down.
+    public func delete(_ key: String) async throws -> Bool {
+        switch self.state {
+        case .initial(_, _, _, _),
+             .running:
+
+            let command = MemcachedRequest.DeleteCommand(key: key)
+            let request = MemcachedRequest.delete(command)
+
+            let response = try await sendRequest(request)
+
+            switch response.returnCode {
+            case .HD:
+                return true
+            case .NF:
+                return false
+            default:
+                return false
+            }
+
+        case .finished:
+            throw MemcachedConnectionError.connectionShutdown
+        }
+    }
 }

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -59,6 +59,8 @@ public actor MemcachedConnection {
         case connectionShutdown
         /// Indicates that a nil response was received from the server.
         case unexpectedNilResponse
+        /// Indicates that the key was not found.
+        case keyNotFound
     }
 
     private var state: State
@@ -269,7 +271,7 @@ public actor MemcachedConnection {
             case .HD:
                 return
             case .NF:
-                throw MemcachedConnectionError.unexpectedNilResponse
+                throw MemcachedConnectionError.keyNotFound
             default:
                 throw MemcachedConnectionError.unexpectedNilResponse
             }

--- a/Sources/SwiftMemcache/MemcachedRequest.swift
+++ b/Sources/SwiftMemcache/MemcachedRequest.swift
@@ -25,6 +25,11 @@ enum MemcachedRequest {
         var flags: MemcachedFlags
     }
 
+    struct DeleteCommand {
+        let key: String
+    }
+
     case set(SetCommand)
     case get(GetCommand)
+    case delete(DeleteCommand)
 }

--- a/Sources/SwiftMemcache/MemcachedRequestEncoder.swift
+++ b/Sources/SwiftMemcache/MemcachedRequestEncoder.swift
@@ -63,6 +63,19 @@ struct MemcachedRequestEncoder: MessageToByteEncoder {
             // write separator
             out.writeInteger(UInt8.carriageReturn)
             out.writeInteger(UInt8.newline)
+
+        case .delete(let command):
+            precondition(!command.key.isEmpty, "Key must not be empty")
+
+            // write command and key
+            out.writeInteger(UInt8.m)
+            out.writeInteger(UInt8.d)
+            out.writeInteger(UInt8.whitespace)
+            out.writeBytes(command.key.utf8)
+
+            // write separator
+            out.writeInteger(UInt8.carriageReturn)
+            out.writeInteger(UInt8.newline)
         }
     }
 }

--- a/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
+++ b/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
@@ -245,13 +245,11 @@ final class MemcachedIntegrationTest: XCTestCase {
             try await memcachedConnection.set("bar", value: setValue)
 
             // Delete the key
-            let deletionSuccess = try await memcachedConnection.delete("bar")
-            XCTAssertTrue(deletionSuccess, "Deletion should be successful")
-
-            // Try to delete the key again
-            let secondDeletionAttempt = try await memcachedConnection.delete("bar")
-            XCTAssertFalse(secondDeletionAttempt, "Second deletion attempt should be unsuccessful")
-
+            do {
+                try await memcachedConnection.delete("bar")
+            } catch {
+                XCTFail("Deletion attempt should be successful, but threw: \(error)")
+            }
             group.cancelAll()
         }
     }

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedRequestEncoderTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedRequestEncoderTests.swift
@@ -139,4 +139,21 @@ final class MemcachedRequestEncoderTests: XCTestCase {
         let expectedEncodedData = "mg foo v\r\n"
         XCTAssertEqual(outBuffer.getString(at: 0, length: outBuffer.readableBytes), expectedEncodedData)
     }
+
+    func testEncodeDeleteRequest() {
+        // Prepare a MemcachedRequest
+        let command = MemcachedRequest.DeleteCommand(key: "foo")
+        let request = MemcachedRequest.delete(command)
+
+        // Pass our request through the encoder
+        var outBuffer = ByteBufferAllocator().buffer(capacity: 0)
+        do {
+            try self.encoder.encode(data: request, out: &outBuffer)
+        } catch {
+            XCTFail("Encoding failed with error: \(error)")
+        }
+
+        let expectedEncodedData = "md foo\r\n"
+        XCTAssertEqual(outBuffer.getString(at: 0, length: outBuffer.readableBytes), expectedEncodedData)
+    }
 }


### PR DESCRIPTION
This PR addresses the need to extend our current Memcached functionality with the addition of a `delete` operation. This operation allows users to remove specific key-value pairs from the cache directly. This PR will close #18.


**Motivation**:
To broaden our interaction capabilities with Memcached servers. The `delete` operation offers users more control over the stored data.

**Modifications**:
* Added a new `DeleteCommand` to our `MemcachedRequest` struct. 
* Updated our `MemcachedRequestEncoder` to handle `delete` operation request 
* Implemented a new a `delete` method to our `MemcachedConnection` that allows for deleting a key-value pair from memcached. 
* Added Unit and Integration test. 


**Results**: 
With the addition of the `delete` operation support, our API now allows users to directly remove key value pairs from cache, enhancing the versatility and control of data within the memcached server. 