### PR TITLE
Implement Append and Prepend Support

### DIFF
--- a/Sources/SwiftMemcache/Extensions/ByteBuffer+SwiftMemcache.swift
+++ b/Sources/SwiftMemcache/Extensions/ByteBuffer+SwiftMemcache.swift
@@ -86,6 +86,19 @@ extension ByteBuffer {
                 }
             }
         }
+
+        if let storageMode = flags.storageMode {
+            switch storageMode {
+            case .append:
+                self.writeInteger(UInt8.whitespace)
+                self.writeInteger(UInt8.M)
+                self.writeInteger(UInt8.A)
+            case .prepend:
+                self.writeInteger(UInt8.whitespace)
+                self.writeInteger(UInt8.M)
+                self.writeInteger(UInt8.P)
+            }
+        }
     }
 }
 

--- a/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
+++ b/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
@@ -22,6 +22,9 @@ extension UInt8 {
     static var d: UInt8 = .init(ascii: "d")
     static var v: UInt8 = .init(ascii: "v")
     static var T: UInt8 = .init(ascii: "T")
+    static var M: UInt8 = .init(ascii: "M")
+    static var P: UInt8 = .init(ascii: "P")
+    static var A: UInt8 = .init(ascii: "A")
     static var zero: UInt8 = .init(ascii: "0")
     static var nine: UInt8 = .init(ascii: "9")
 }

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -280,4 +280,64 @@ public actor MemcachedConnection {
             throw MemcachedConnectionError.connectionShutdown
         }
     }
+
+    // MARK: - Prepending a Value
+
+    /// Prepend a value to an existing key in the Memcache server.
+    ///
+    /// - Parameters:
+    ///   - key: The key to prepend the value to.
+    ///   - value: The `MemcachedValue` to prepend.
+    /// - Throws: A `MemcachedConnectionError` if the connection to the Memcached server is shut down.
+    public func prepend(_ key: String, value: some MemcachedValue) async throws {
+        switch self.state {
+        case .initial(_, let bufferAllocator, _, _),
+             .running(let bufferAllocator, _, _, _):
+
+            var buffer = bufferAllocator.buffer(capacity: 0)
+            value.writeToBuffer(&buffer)
+            var flags: MemcachedFlags?
+
+            flags = MemcachedFlags()
+            flags?.storageMode = .prepend
+
+            let command = MemcachedRequest.SetCommand(key: key, value: buffer, flags: flags)
+            let request = MemcachedRequest.set(command)
+
+            _ = try await self.sendRequest(request)
+
+        case .finished:
+            throw MemcachedConnectionError.connectionShutdown
+        }
+    }
+
+    // MARK: - Appending a Value
+
+    /// Append a value to an existing key in the Memcache server.
+    ///
+    /// - Parameters:
+    ///   - key: The key to append the value to.
+    ///   - value: The `MemcachedValue` to append.
+    /// - Throws: A `MemcachedConnectionError` if the connection to the Memcached server is shut down.
+    public func append(_ key: String, value: some MemcachedValue) async throws {
+        switch self.state {
+        case .initial(_, let bufferAllocator, _, _),
+             .running(let bufferAllocator, _, _, _):
+
+            var buffer = bufferAllocator.buffer(capacity: 0)
+            value.writeToBuffer(&buffer)
+            var flags: MemcachedFlags?
+
+            flags = MemcachedFlags()
+            flags?.storageMode = .append
+
+            let command = MemcachedRequest.SetCommand(key: key, value: buffer, flags: flags)
+            let request = MemcachedRequest.set(command)
+
+            _ = try await self.sendRequest(request)
+
+        case .finished:
+            throw MemcachedConnectionError.connectionShutdown
+        }
+    }
 }

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -296,10 +296,10 @@ public actor MemcachedConnection {
 
             var buffer = bufferAllocator.buffer(capacity: 0)
             value.writeToBuffer(&buffer)
-            var flags: MemcachedFlags?
+            var flags: MemcachedFlags
 
             flags = MemcachedFlags()
-            flags?.storageMode = .prepend
+            flags.storageMode = .prepend
 
             let command = MemcachedRequest.SetCommand(key: key, value: buffer, flags: flags)
             let request = MemcachedRequest.set(command)
@@ -326,10 +326,10 @@ public actor MemcachedConnection {
 
             var buffer = bufferAllocator.buffer(capacity: 0)
             value.writeToBuffer(&buffer)
-            var flags: MemcachedFlags?
+            var flags: MemcachedFlags
 
             flags = MemcachedFlags()
-            flags?.storageMode = .append
+            flags.storageMode = .append
 
             let command = MemcachedRequest.SetCommand(key: key, value: buffer, flags: flags)
             let request = MemcachedRequest.set(command)

--- a/Sources/SwiftMemcache/MemcachedFlags.swift
+++ b/Sources/SwiftMemcache/MemcachedFlags.swift
@@ -31,6 +31,12 @@ struct MemcachedFlags {
     /// If set, the item is considered to be expired after this number of seconds.
     var timeToLive: TimeToLive?
 
+    /// Mode for the 'ms' (meta set) command (corresponding to the 'M' flag).
+    ///
+    /// Represents the mode of the 'ms' command, which determines the behavior of the data operation.
+    /// The default mode is 'set'.
+    var storageMode: StorageMode?
+
     init() {}
 }
 
@@ -40,6 +46,14 @@ public enum TimeToLive: Equatable, Hashable {
     case indefinitely
     /// The value should expire after a specified time.
     case expiresAt(ContinuousClock.Instant)
+}
+
+/// Enum representing the Memcached 'ms' (meta set) command modes (corresponding to the 'M' flag).
+public enum StorageMode: Equatable, Hashable {
+    /// The 'append' command. If the item exists, append the new value to its data.
+    case append
+    /// The 'prepend' command. If the item exists, prepend the new value to its data.
+    case prepend
 }
 
 extension MemcachedFlags: Hashable {}

--- a/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
+++ b/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
@@ -254,6 +254,58 @@ final class MemcachedIntegrationTest: XCTestCase {
         }
     }
 
+    func testPrependValue() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try! group.syncShutdownGracefully())
+        }
+        let memcachedConnection = MemcachedConnection(host: "memcached", port: 11211, eventLoopGroup: group)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await memcachedConnection.run() }
+
+            // Set key and initial value
+            let initialValue = "foo"
+            try await memcachedConnection.set("greet", value: initialValue)
+
+            // Prepend value to key
+            let prependValue = "Hi"
+            try await memcachedConnection.prepend("greet", value: prependValue)
+
+            // Get value for key after prepend operation
+            let updatedValue: String? = try await memcachedConnection.get("greet")
+            XCTAssertEqual(updatedValue, prependValue + initialValue, "Received value should be the same as the concatenation of prependValue and initialValue")
+
+            group.cancelAll()
+        }
+    }
+
+    func testAppendValue() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try! group.syncShutdownGracefully())
+        }
+        let memcachedConnection = MemcachedConnection(host: "memcached", port: 11211, eventLoopGroup: group)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await memcachedConnection.run() }
+
+            // Set key and initial value
+            let initialValue = "hi"
+            try await memcachedConnection.set("greet", value: initialValue)
+
+            // Append value to key
+            let appendValue = "foo"
+            try await memcachedConnection.append("greet", value: appendValue)
+
+            // Get value for key after append operation
+            let updatedValue: String? = try await memcachedConnection.get("greet")
+            XCTAssertEqual(updatedValue, initialValue + appendValue, "Received value should be the same as the concatenation of initialValue and appendValue")
+
+            group.cancelAll()
+        }
+    }
+
     func testMemcachedConnectionWithUInt() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagsTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagsTests.swift
@@ -37,4 +37,24 @@ final class MemcachedFlagsTests: XCTestCase {
             XCTFail("Flag timeToLive is nil")
         }
     }
+
+    func testStorageModeAppend() {
+        var flags = MemcachedFlags()
+        flags.storageMode = .append
+        if case .append? = flags.storageMode {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Flag storageMode is not .append")
+        }
+    }
+
+    func testStorageModePrepend() {
+        var flags = MemcachedFlags()
+        flags.storageMode = .prepend
+        if case .prepend? = flags.storageMode {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Flag storageMode is not .prepend")
+        }
+    }
 }


### PR DESCRIPTION
This PR  address the need to enhance our memcached functionality with `append` and `prepend` operation support. These operations enable modifying stored key-value pairs by appending and prepending data to the existing values, reading the need for read-modifying-write cycles. This PR will close #19.

**Motivation**:
To improve our interactions with memcached servers in a more dynamic and versatile way. `Append` and `Prepend` operations not only increase cache efficiency by minimizing network round trips for data modification but also broadens our API capabilities. 

**Modifications**: 
* Added `append` and `prepend` methods to `MemcachedConnection`. 
* Created a `StorageMode` enum that represent the different ways data can be stored or manipulated for a particular key. 
* Added `storageMode` property to `MemcachedFlags` to specify whether he operation is `append` or `prepend`. 
* Added Unit test and Integration test. 

**Results**: 
With the addition of append and prepend support, our API now allows users to modify existing data in the cache directly, improving cache efficiency and expanding the versatility of our API. 