### PR TITLE
Implement `Add` and `Replace` support

### DIFF
--- a/Sources/SwiftMemcache/Extensions/ByteBuffer+SwiftMemcache.swift
+++ b/Sources/SwiftMemcache/Extensions/ByteBuffer+SwiftMemcache.swift
@@ -88,15 +88,17 @@ extension ByteBuffer {
         }
 
         if let storageMode = flags.storageMode {
+            self.writeInteger(UInt8.whitespace)
+            self.writeInteger(UInt8.M)
             switch storageMode {
+            case .add:
+                self.writeInteger(UInt8.E)
             case .append:
-                self.writeInteger(UInt8.whitespace)
-                self.writeInteger(UInt8.M)
                 self.writeInteger(UInt8.A)
             case .prepend:
-                self.writeInteger(UInt8.whitespace)
-                self.writeInteger(UInt8.M)
                 self.writeInteger(UInt8.P)
+            case .replace:
+                self.writeInteger(UInt8.R)
             }
         }
     }

--- a/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
+++ b/Sources/SwiftMemcache/Extensions/UInt8+Characters.swift
@@ -25,6 +25,8 @@ extension UInt8 {
     static var M: UInt8 = .init(ascii: "M")
     static var P: UInt8 = .init(ascii: "P")
     static var A: UInt8 = .init(ascii: "A")
+    static var E: UInt8 = .init(ascii: "E")
+    static var R: UInt8 = .init(ascii: "R")
     static var zero: UInt8 = .init(ascii: "0")
     static var nine: UInt8 = .init(ascii: "9")
 }

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -345,7 +345,7 @@ public actor MemcachedConnection {
 
     // MARK: - Adding a Value
 
-    /// Adds a value to a new key in the Memcached server.
+    /// Adds a new key-value pair in the Memcached server.
     /// The operation will fail if the key already exists.
     ///
     /// - Parameters:
@@ -409,7 +409,16 @@ public actor MemcachedConnection {
             let command = MemcachedRequest.SetCommand(key: key, value: buffer, flags: flags)
             let request = MemcachedRequest.set(command)
 
-            _ = try await self.sendRequest(request)
+            let response = try await sendRequest(request)
+
+            switch response.returnCode {
+            case .HD:
+                return
+            case .NS:
+                throw MemcachedConnectionError.keyNotFound
+            default:
+                throw MemcachedConnectionError.unexpectedNilResponse
+            }
 
         case .finished:
             throw MemcachedConnectionError.connectionShutdown

--- a/Sources/SwiftMemcache/MemcachedFlags.swift
+++ b/Sources/SwiftMemcache/MemcachedFlags.swift
@@ -50,10 +50,14 @@ public enum TimeToLive: Equatable, Hashable {
 
 /// Enum representing the Memcached 'ms' (meta set) command modes (corresponding to the 'M' flag).
 public enum StorageMode: Equatable, Hashable {
+    /// The "add" command. If the item exists, LRU is bumped and NS is returned.
+    case add
     /// The 'append' command. If the item exists, append the new value to its data.
     case append
     /// The 'prepend' command. If the item exists, prepend the new value to its data.
     case prepend
+    /// The "replace" command. The new value is set only if the item already exists.
+    case replace
 }
 
 extension MemcachedFlags: Hashable {}

--- a/Sources/SwiftMemcache/MemcachedFlags.swift
+++ b/Sources/SwiftMemcache/MemcachedFlags.swift
@@ -49,7 +49,7 @@ public enum TimeToLive: Equatable, Hashable {
 }
 
 /// Enum representing the Memcached 'ms' (meta set) command modes (corresponding to the 'M' flag).
-public enum StorageMode: Equatable, Hashable {
+enum StorageMode: Equatable, Hashable {
     /// The "add" command. If the item exists, LRU is bumped and NS is returned.
     case add
     /// The 'append' command. If the item exists, append the new value to its data.

--- a/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
+++ b/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
@@ -318,6 +318,7 @@ final class MemcachedIntegrationTest: XCTestCase {
 
             // Add a value to a key
             let addValue = "foo"
+
             try await memcachedConnection.delete("adds")
             try await memcachedConnection.add("adds", value: addValue)
 

--- a/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
+++ b/Tests/SwiftMemcacheTests/IntegrationTest/MemcachedIntegrationTests.swift
@@ -319,7 +319,16 @@ final class MemcachedIntegrationTest: XCTestCase {
             // Add a value to a key
             let addValue = "foo"
 
-            try await memcachedConnection.delete("adds")
+            // Attempt to delete the key, but ignore the error if it doesn't exist
+            do {
+                try await memcachedConnection.delete("adds")
+            } catch {
+                if "\(error)" != "keyNotFound" {
+                    throw error
+                }
+            }
+
+            // Proceed with adding the key-value pair
             try await memcachedConnection.add("adds", value: addValue)
 
             // Get value for the key after add operation
@@ -344,8 +353,16 @@ final class MemcachedIntegrationTest: XCTestCase {
             let initialValue = "foo"
             let newValue = "bar"
 
-            // Ensure the key is clean and add an initial value
-            try await memcachedConnection.delete("adds")
+            // Attempt to delete the key, but ignore the error if it doesn't exist
+            do {
+                try await memcachedConnection.delete("adds")
+            } catch {
+                if "\(error)" != "keyNotFound" {
+                    throw error
+                }
+            }
+
+            // Set an initial value for the key
             try await memcachedConnection.add("adds", value: initialValue)
 
             do {

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagsTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedFlagsTests.swift
@@ -38,6 +38,16 @@ final class MemcachedFlagsTests: XCTestCase {
         }
     }
 
+    func testStorageModeAdd() {
+        var flags = MemcachedFlags()
+        flags.storageMode = .add
+        if case .add? = flags.storageMode {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Flag storageMode is not .add")
+        }
+    }
+
     func testStorageModeAppend() {
         var flags = MemcachedFlags()
         flags.storageMode = .append
@@ -55,6 +65,16 @@ final class MemcachedFlagsTests: XCTestCase {
             XCTAssertTrue(true)
         } else {
             XCTFail("Flag storageMode is not .prepend")
+        }
+    }
+
+    func testStorageModeReplace() {
+        var flags = MemcachedFlags()
+        flags.storageMode = .replace
+        if case .replace? = flags.storageMode {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Flag storageMode is not .replace")
         }
     }
 }

--- a/Tests/SwiftMemcacheTests/UnitTest/MemcachedRequestEncoderTests.swift
+++ b/Tests/SwiftMemcacheTests/UnitTest/MemcachedRequestEncoderTests.swift
@@ -48,38 +48,37 @@ final class MemcachedRequestEncoderTests: XCTestCase {
         XCTAssertEqual(outBuffer.getString(at: 0, length: outBuffer.readableBytes), expectedEncodedData)
     }
 
-    func testEncodeAppendRequest() {
+    func testEncodeStorageRequest(withMode mode: StorageMode, expectedEncodedData: String) {
         // Prepare a MemcachedRequest
         var buffer = ByteBufferAllocator().buffer(capacity: 2)
         buffer.writeString("hi")
 
         var flags = MemcachedFlags()
-        flags.storageMode = .append
+        flags.storageMode = mode
         let command = MemcachedRequest.SetCommand(key: "foo", value: buffer, flags: flags)
         let request = MemcachedRequest.set(command)
 
         // pass our request through the encoder
         let outBuffer = self.encodeRequest(request)
 
-        let expectedEncodedData = "ms foo 2 MA\r\nhi\r\n"
+        // assert the encoded request
         XCTAssertEqual(outBuffer.getString(at: 0, length: outBuffer.readableBytes), expectedEncodedData)
     }
 
+    func testEncodeAppendRequest() {
+        self.testEncodeStorageRequest(withMode: .append, expectedEncodedData: "ms foo 2 MA\r\nhi\r\n")
+    }
+
     func testEncodePrependRequest() {
-        // Prepare a MemcachedRequest
-        var buffer = ByteBufferAllocator().buffer(capacity: 2)
-        buffer.writeString("hi")
+        self.testEncodeStorageRequest(withMode: .prepend, expectedEncodedData: "ms foo 2 MP\r\nhi\r\n")
+    }
 
-        var flags = MemcachedFlags()
-        flags.storageMode = .prepend
-        let command = MemcachedRequest.SetCommand(key: "foo", value: buffer, flags: flags)
-        let request = MemcachedRequest.set(command)
+    func testEncodeAddRequest() {
+        self.testEncodeStorageRequest(withMode: .add, expectedEncodedData: "ms foo 2 ME\r\nhi\r\n")
+    }
 
-        // pass our request through the encoder
-        let outBuffer = self.encodeRequest(request)
-
-        let expectedEncodedData = "ms foo 2 MP\r\nhi\r\n"
-        XCTAssertEqual(outBuffer.getString(at: 0, length: outBuffer.readableBytes), expectedEncodedData)
+    func testEncodeReplaceRequest() {
+        self.testEncodeStorageRequest(withMode: .replace, expectedEncodedData: "ms foo 2 MR\r\nhi\r\n")
     }
 
     func testEncodeTouchRequest() {


### PR DESCRIPTION
This PR addresses the need to enhance our Memcache functionality with `add` and `replace` operation support. These operations enable modifying key-value pairs by providing a more granular level of control over how data is stored. This PR closes #25.

**Motivation**:
To improve our interactions with memcached servers in a more dynamic and versatile way. `Add` and `Replace` operations not only increase cache efficiency by minimizing network round trips for data modification but also broadens our API capabilities.

**Modifications**: 
* Added `add` and `replace` methods to `MemcachedConnection`. 
* Modified our `StorageMode` enum to handle `add` and `replace` state.
* Added Unit test and integration test. 

**Result**:
With the addition of `add` and `replace` support, our API now allows users to add and modify data in the cache directly, improving cache efficiency and expanding the versatility of our API.

