### PR TITLE
Adapt `Service` protocol from `swift-service-lifecycle`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
     ],
     targets: [
         .target(
@@ -41,6 +42,7 @@ let package = Package(
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ]
         ),
         .testTarget(

--- a/Sources/SwiftMemcache/MemcachedConnection.swift
+++ b/Sources/SwiftMemcache/MemcachedConnection.swift
@@ -15,11 +15,12 @@
 
 import NIOCore
 import NIOPosix
+import ServiceLifecycle
 
 /// An actor to create a connection to a Memcache server.
 ///
 /// This actor can be used to send commands to the server.
-public actor MemcachedConnection {
+public actor MemcachedConnection: Service {
     private typealias StreamElement = (MemcachedRequest, CheckedContinuation<MemcachedResponse, Error>)
     private let host: String
     private let port: Int

--- a/Sources/swift-memcache-gsoc-example/Program.swift
+++ b/Sources/swift-memcache-gsoc-example/Program.swift
@@ -29,16 +29,8 @@ struct Program {
         // Instantiate a new MemcacheConnection actor with host, port, and event loop group
         let memcacheConnection = MemcachedConnection(host: "127.0.0.1", port: 11211, eventLoopGroup: eventLoopGroup)
 
-        // Initialize the ServiceGroupConfiguration
-        let serviceGroupConfiguration = ServiceGroupConfiguration(
-            services: [ServiceGroupConfiguration.ServiceConfiguration(service: memcacheConnection)],
-            gracefulShutdownSignals: [],
-            cancellationSignals: [],
-            logger: self.logger
-        )
-
         // Initialize the service group
-        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+        let serviceGroup = ServiceGroup(services: [memcacheConnection], logger: self.logger)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Add the connection actor's run function to the task group

--- a/Sources/swift-memcache-gsoc-example/Program.swift
+++ b/Sources/swift-memcache-gsoc-example/Program.swift
@@ -12,31 +12,46 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 import NIOCore
 import NIOPosix
+import ServiceLifecycle
 import SwiftMemcache
 
 @main
 struct Program {
-    // Create an event loop group with a single thread
-    static let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    // Use the shared singleton instance of MultiThreadedEventLoopGroup
+    static let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+    // Initialize the logger
+    static let logger = Logger(label: "memcache")
 
     static func main() async throws {
-        // Instantiate a new MemcachedConnection actor with host, port, and event loop group
-        let memcachedConnection = MemcachedConnection(host: "127.0.0.1", port: 11211, eventLoopGroup: eventLoopGroup)
+        // Instantiate a new MemcacheConnection actor with host, port, and event loop group
+        let memcacheConnection = MemcachedConnection(host: "127.0.0.1", port: 11211, eventLoopGroup: eventLoopGroup)
+
+        // Initialize the ServiceGroupConfiguration
+        let serviceGroupConfiguration = ServiceGroupConfiguration(
+            services: [ServiceGroupConfiguration.ServiceConfiguration(service: memcacheConnection)],
+            gracefulShutdownSignals: [],
+            cancellationSignals: [],
+            logger: self.logger
+        )
+
+        // Initialize the service group
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Add the connection actor's run function to the task group
             // This opens the connection and handles requests until the task is cancelled or the connection is closed
-            group.addTask { try await memcachedConnection.run() }
+            group.addTask { try await serviceGroup.run() }
 
             // Set a value for a key.
             let setValue = "bar"
-            try await memcachedConnection.set("foo", value: setValue)
+            try await memcacheConnection.set("foo", value: setValue)
 
             // Get the value for a key.
             // Specify the expected type for the value returned from Memcache.
-            let getValue: String? = try await memcachedConnection.get("foo")
+            let getValue: String? = try await memcacheConnection.get("foo")
 
             // Assert that the get operation was successful by comparing the value set and the value returned from Memcache.
             // If they are not equal, this will throw an error.


### PR DESCRIPTION
This PR address the need to integrate [swift-service-lifecycle's](https://github.com/swift-server/swift-service-lifecycle) [`Service`](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/main/documentation/servicelifecycle/service) protocol into our `MemcachedConnection`.  
The incorporation of the Service protocol will ensure a unified and standardized lifecycle management for our Memcached service. This PR will close #36.

**Motivation**:
To adopt industry standards for service lifecycle management and improve the maintainability and operability of our `MemcachedConnection`. Incorporating the `Service` protocol enhances the way we manage the startup and shutdown procedures of the service.

**Modifications**:
* Implemented the `Service` protocol in `MemcachedConnection`.
* Updated our Program example to now use `ServiceGroup` initialization to include `MemcachedConnection` as a `Service`. 

**Results**:
With the integration of the `Service` protocol, `MemcachedConnection` now benefits from standardized lifecycle management. This improves the reliability of the service and makes it easier to manage in production setups.