### PR TITLE
Add CI pipeline for Swift 5.10

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -3,18 +3,17 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-memcache-gsoc:22.04-5.9
+    image: swift-memcache-gsoc:22.04-5.10
     build:
       args:
-        ubuntu_version: "jammy"
-        swift_version: "5.9"
+        base_image: "swiftlang/swift:nightly-5.10-jammy"
 
   test:
-    image: swift-memcache-gsoc:22.04-5.9
+    image: swift-memcache-gsoc:22.04-5.10
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:
-    image: swift-memcache-gsoc:22.04-5.9
+    image: swift-memcache-gsoc:22.04-5.10

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,8 +6,10 @@ services:
   
   memcached:
     image: memcached:latest
+    networks:
+      - memcached
     ports:
-        - "11211:11211"
+        - 11211
   
   runtime-setup:
     image: swift-memcache-gsoc:default
@@ -33,9 +35,16 @@ services:
         - runtime-setup
         - memcached
     command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-}"
+    networks:
+      - memcached
 
   # util
 
   shell:
     <<: *common
     entrypoint: /bin/bash
+
+# dedicated network
+
+networks:
+  memcached:


### PR DESCRIPTION
Motivation:

Now that Swift 5.9 is GM we should update the CI pipelines

Modifications:

* Add a 5.10 nightly docker compose file
* Update the 5.9 compose file to stop using nightlies

Result:

Remove add CI support for 5.10