### PR TITLE
Enable MemberImportVisibility check on 6.0+ pipelines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
     with:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,9 +17,9 @@ jobs:
     with:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility"
 
   cxx-interop:
     name: Cxx interop


### PR DESCRIPTION
Enable MemberImportVisibility check on 6.0+ pipelines