### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project

--- a/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Decrement_Request.p90.json
+++ b/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Decrement_Request.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 506
-}

--- a/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Delete_Request.p90.json
+++ b/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Delete_Request.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 506
-}

--- a/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Increment_Request.p90.json
+++ b/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Increment_Request.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 507
-}

--- a/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Set_Request.p90.json
+++ b/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Set_Request.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 578
-}

--- a/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Set_with_TTL_Request.p90.json
+++ b/Benchmarks/Thresholds/5.9/MemcacheBenchmarks.Set_with_TTL_Request.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 578
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-memcache-gsoc open source project


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
