### PR TITLE
Update unit_tests.yml to remove Swift 5.9 job

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: "swift test"
+          COMMAND_OVERRIDE_5_9: ""
           COMMAND_OVERRIDE_5_10: "swift test ${{ inputs.linux_5_10_arguments_override }}"
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
           COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,14 +3,6 @@ name: Unit tests
 on:
   workflow_call:
     inputs:
-      linux_5_9_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 5.9 Swift version matrix job. Defaults to true."
-        default: true
-      linux_5_9_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Linux 5.9 Swift version matrix job."
-        default: ""
       linux_5_10_enabled:
         type: boolean
         description: "Boolean to enable the Linux 5.10 Swift version matrix job. Defaults to true."
@@ -61,9 +53,6 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: "swift:5.9-jammy"
-            swift_version: "5.9"
-            enabled: ${{ inputs.linux_5_9_enabled }}
           - image: "swift:5.10-jammy"
             swift_version: "5.10"
             enabled: ${{ inputs.linux_5_10_enabled }}
@@ -95,7 +84,6 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: "swift test"
-          COMMAND_OVERRIDE_5_9: "swift test ${{ inputs.linux_5_9_arguments_override }}"
           COMMAND_OVERRIDE_5_10: "swift test ${{ inputs.linux_5_10_arguments_override }}"
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
           COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"


### PR DESCRIPTION
Update unit_tests.yml to remove Swift 5.9 job since 5.9 is no longer supported
