### PR TITLE
Enable Swift 6.3 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   release-builds:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ jobs:
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,6 +27,14 @@ on:
         type: string
         description: "The arguments passed to swift test in the Linux 6.2 Swift version matrix job."
         default: ""
+      linux_6_3_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.3 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_3_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.3 Swift version matrix job."
+        default: ""
       linux_nightly_main_enabled:
         type: boolean
         description: "Boolean to enable the Linux nightly main Swift version matrix job. Defaults to true."
@@ -54,6 +62,9 @@ jobs:
           - image: "swift:6.2-jammy"
             swift_version: "6.2"
             enabled: ${{ inputs.linux_6_2_enabled }}
+          - image: "swift:6.3-noble"
+            swift_version: "6.3"
+            enabled: ${{ inputs.linux_6_3_enabled }}
           - image: "swiftlang/swift:nightly-main-jammy"
             swift_version: "nightly-main"
             enabled: ${{ inputs.linux_nightly_main_enabled }}
@@ -76,6 +87,7 @@ jobs:
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
           COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_6_2: "swift test ${{ inputs.linux_6_2_arguments_override }}"
+          COMMAND_OVERRIDE_6_3: "swift test ${{ inputs.linux_6_3_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
         run: |
           apt-get -qq update && apt-get -qq -y install curl


### PR DESCRIPTION
Motivation

* Swift 6.3 has been released, we should add it to our CI coverage.

Modifications

* Add additional Swift 6.3 jobs where appropriate in `main.yml`, `pull_request.yml`, `unit_tests.yml`

Result

* Improved test coverage.
