### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,14 +3,6 @@ name: Unit tests
 on:
   workflow_call:
     inputs:
-      linux_6_0_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 6.0 Swift version matrix job. Defaults to true."
-        default: true
-      linux_6_0_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
-        default: ""
       linux_6_1_enabled:
         type: boolean
         description: "Boolean to enable the Linux 6.1 Swift version matrix job. Defaults to true."
@@ -53,9 +45,6 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: "swift:6.0-jammy"
-            swift_version: "6.0"
-            enabled: ${{ inputs.linux_6_0_enabled }}
           - image: "swift:6.1-jammy"
             swift_version: "6.1"
             enabled: ${{ inputs.linux_6_1_enabled }}
@@ -84,7 +73,6 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: "swift test"
-          COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
           COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_6_2: "swift test ${{ inputs.linux_6_2_arguments_override }}"
           COMMAND_OVERRIDE_6_3: "swift test ${{ inputs.linux_6_3_arguments_override }}"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-memcache-gsoc open source project


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
